### PR TITLE
General Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "0.10"
+  - "4"
+  - "5"

--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@
 
 Plugin that generate sprites from your stylesheets (using [spritesmith](https://github.com/Ensighten/spritesmith)) and then updates image references.
 
-## Getting started
+## Getting Started
 
 If you haven't used [gulp](http://gulpjs.com) before, be sure to check out the [Getting Started](https://github.com/gulpjs/gulp/blob/master/docs/getting-started.md) guide.
 
-Install with [npm](https://npmjs.org/package/gulp-sprite-generator)
+Install with [npm](https://npmjs.org/package/gulp-sprite-generator):
 
+```sh
+$ npm install --save-dev gulp-sprite-generator
 ```
-npm install --save-dev gulp-sprite-generator
+
+You also should install a spritesmith engine:
+
+```sh
+$ npm install --save-dev pixelsmith
 ```
 
 ## Overview
@@ -113,7 +119,7 @@ For example: `image@2x.png`.
 Type: `Function[]`, `Function`
 Default value: `[]`
 
-Defines which filters apply to images found in the input stylesheet. Each filer called with image object, explained below. Each filter must return `Boolean` or
+Defines which filters apply to images found in the input stylesheet. Each filter is called with the image object, explained below. Each filter must return `Boolean` or
 [thenable `Promise`](https://github.com/promises-aplus/promises-spec), that will be resolved with `Boolean`. Each filter
 applies in series.
 
@@ -173,9 +179,8 @@ You can also define some properties for the filters and groupers in doc block vi
 Example:
 
 ```css
-
 .my_class {
-    background-image: url("/images/my.png"); /* @meta {"sprite": {"skip": true}} */
+	background-image: url("/images/my.png"); /* @meta {"sprite": {"skip": true}} */
 }
 
 ```
@@ -186,52 +191,48 @@ Example:
 ### Flexible example
 
 ```javascript
-
-var gulp   = require('gulp'),
-    sprite = require('gulp-sprite-generator'),
-    Q      = require('q'),
-    sizeOf = require('image-size');
+var gulp = require('gulp');
+var sprite = require('gulp-sprite-generator');
+var Promise = require('es6-promise').Promise;
+var sizeOf = require('image-size');
 
 gulp.task('sprites', function() {
-    var spriteOutput;
-
-	spriteOutput = gulp.src("./src/css/*.css")
+	var spriteOutput = gulp.src('./src/css/*.css')
 		.pipe(sprite({
-            baseUrl:         "./",
-            spriteSheetName: "sprite.png",
-            spriteSheetPath: "/dist/image",
-            styleSheetName:  "stylesheet.css",
+			baseUrl: './',
+			engine: 'pixelsmith',
+			spriteSheetName: 'sprite.png',
+			spriteSheetPath: '/dist/image',
+			styleSheetName: 'stylesheet.css',
 
-            filter: [
-                // this is a copy of built in filter of meta skip
-                // do not forget to set it up in your stylesheets using doc block /* */
-                function(image) {
-                    return !image.meta.skip;
-                }
-            ],
+			filter: [
+				// this is a copy of built in filter of meta skip
+				// do not forget to set it up in your stylesheets using doc block /* */
+				function(image) {
+					return !image.meta.skip;
+				}
+			],
 
-            groupBy: [
-                // group images by width
-                // useful when building background repeatable sprites
-                function(image) {
-                    var deferred = Q.defer();
-
-                    sizeOf(image.path, function(err, size) {
-                        deferred.resolve(size.width.toString());
-                    });
-
-                    return deferred.promise;
-                }
-            ]
+			groupBy: [
+				// group images by width
+				// useful when building background repeatable sprites
+				function(image) {
+					return new Promise(function(resolve, reject) {
+						sizeOf(image.path, function(err, size) {
+							if (err) return reject(err);
+							resolve(size.width.toString());
+						});
+					});
+				}
+			]
 		});
 
-    spriteOutput.css.pipe(gulp.dest("./dist/css"));
-    spriteOutput.img.pipe(gulp.dest("./dist/image"));
-});
+	spriteOutput.css.pipe(gulp.dest('./dist/css'));
+	spriteOutput.img.pipe(gulp.dest('./dist/image'));
 
+});
 ```
 
 ## License
 
 MIT © [Sergey Kamardin](http://github.com/gobwas)
-

--- a/index.js
+++ b/index.js
@@ -1,529 +1,476 @@
-var path        = require('path'),
-    spritesmith = require('spritesmith'),
-    File        = require('vinyl'),
-    _           = require('lodash'),
-    colors      = require('colors'),
-    fs          = require('fs'),
-    gutil       = require('gulp-util'),
-    util        = require("util"),
-    async       = require('async'),
-    Q           = require('q'),
-    through     = require('through2'),
-    Readable    = require('stream').Readable,
+var _           = require('lodash');
+var fs          = require('fs');
+var path        = require('path');
+var util        = require("util");
+var gutil       = require('gulp-util');
+var async       = require('async');
+var File        = require('vinyl');
+var Spritesmith = require('spritesmith');
+var colors      = require('colors');
+var through2    = require('through2');
+var Promise     = require('es6-promise').Promise;
+var Readable    = require('stream').Readable;
 
-    PLUGIN_NAME = "gulp-sprite-generator",
-    debug;
+var PLUGIN_NAME = 'gulp-sprite-generator';
+var debug;
 
-var log = function() {
-    var args, sig;
-
-    args = Array.prototype.slice.call(arguments);
-    sig = '[' + colors.green(PLUGIN_NAME) + ']';
-    args.unshift(sig);
-
-    gutil.log.apply(gutil, args);
-};
+function log() {
+	var args = Array.prototype.slice.call(arguments);
+	var sig = '[' + colors.green(PLUGIN_NAME) + ']';
+	args.unshift(sig);
+	gutil.log.apply(gutil, args);
+}
 
 var getImages = (function() {
-    var httpRegex, imageRegex, filePathRegex, pngRegex, retinaRegex;
+	var imageRegex     = new RegExp('background-image\s*:[\\s]?url\\(["\']?([\\w\\d\\s!:./\\-\\_@]*\\.[\\w?#]+)["\']?\\)[^;]*\\;(?:\\s*\\/\\*\\s*@meta\\s*(\\{.*\\})\\s*\\*\\/)?', 'ig');
+	var retinaRegex    = new RegExp('@(\\d)x\\.[a-z]{3,4}$', 'ig');
+	var httpRegex      = new RegExp('https?', 'ig');
+	var imagePathRegex = new RegExp('\\.(png|jpe?g)$', 'ig');
+	var filePathRegex  = new RegExp('["\']?([\\w\\d\\s! :./\\-\\_@]*\\.[\\w?#]+)["\']?', 'ig');
 
-    imageRegex    = new RegExp('background-image:[\\s]?url\\(["\']?([\\w\\d\\s!:./\\-\\_@]*\\.[\\w?#]+)["\']?\\)[^;]*\\;(?:\\s*\\/\\*\\s*@meta\\s*(\\{.*\\})\\s*\\*\\/)?', 'ig');
-    retinaRegex   = new RegExp('@(\\d)x\\.[a-z]{3,4}$', 'ig');
-    httpRegex     = new RegExp('http[s]?', 'ig');
-    pngRegex      = new RegExp('\\.png$', 'ig');
-    filePathRegex = new RegExp('["\']?([\\w\\d\\s!:./\\-\\_@]*\\.[\\w?#]+)["\']?', 'ig');
+	return function(file, options) {
+		var reference, images,
+			retina, filePath,
+			url, image, meta, basename,
+			makeRegexp, content;
 
-    return function(file, options) {
-        var reference, images,
-            retina, filePath,
-            url, image, meta, basename,
-            makeRegexp, content;
+		images = [];
+		content = file.contents.toString();
+		basename = path.basename(file.path);
 
-        content = file.contents.toString();
+		makeRegexp = (function() {
+			var matchOperatorsRe = /[|\\/{}()[\]^$+*?.]/g;
+			return function(str) {
+				return str.replace(matchOperatorsRe,	'\\$&');
+			}
+		})();
 
-        images = [];
+		while ((reference = imageRegex.exec(content)) != null) {
+			url	 = reference[1];
+			meta	= reference[2];
 
-        basename = path.basename(file.path);
+			image = {
+				replacement: new RegExp('background-image:\\s+url\\(\\s?(["\']?)\\s?' + makeRegexp(url) + '\\s?\\1\\s?\\)[^;]*\\;', 'gi'),
+				url: url,
+				group: [],
+				isRetina:	false,
+				retinaRatio: 1,
+				meta: {}
+			};
 
-        makeRegexp = (function() {
-            var matchOperatorsRe = /[|\\/{}()[\]^$+*?.]/g;
+			if (httpRegex.test(url)) {
+				options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s an external resource');
+				continue;
+			}
 
-            return function(str) {
-                return str.replace(matchOperatorsRe,  '\\$&');
-            }
-        })();
+			if (!imagePathRegex.test(url)) {
+				options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s not a png or jpeg');
+				continue;
+			}
 
-        while ((reference = imageRegex.exec(content)) != null) {
-            url   = reference[1];
-            meta  = reference[2];
+			if (meta) {
+				try {
+					meta = JSON.parse(meta);
+					meta.sprite && (image.meta = meta.sprite);
+				} catch (err) {
+					log(colors.cyan(basename) + ' > ' + colors.white('Can not parse meta json for ' + url) + ': "' + colors.red(err) + '"');
+				}
+			}
 
-            image = {
-                replacement: new RegExp('background-image:\\s+url\\(\\s?(["\']?)\\s?' + makeRegexp(url) + '\\s?\\1\\s?\\)[^;]*\\;', 'gi'),
-                url:         url,
-                group:       [],
-                isRetina:    false,
-                retinaRatio: 1,
-                meta:        {}
-            };
+			if (options.retina && (retina = retinaRegex.exec(url))) {
+				image.isRetina = true;
+				image.retinaRatio = retina[1];
+			}
 
-            if (httpRegex.test(url)) {
-                options.verbose && log(colors.cyan(basename) + ' > ' + url + ' has been skipped as it\'s an external resource!');
-                continue;
-            }
+			filePath = filePathRegex.exec(url)[0].replace(/['"]/g, '');
 
-            if (!pngRegex.test(url)) {
-                options.verbose && log(colors.cyan(basename) + ' > ' + url + ' has been skipped as it\'s not a PNG!');
-                continue;
-            }
+			// if url to image is relative
+			if(filePath.charAt(0) === "/") {
+				filePath = path.resolve(options.baseUrl + filePath);
+			} else {
+				filePath = path.resolve(file.path.substring(0, file.path.lastIndexOf(path.sep)), filePath);
+			}
 
-            if (meta) {
-                try {
-                    meta = JSON.parse(meta);
-                    meta.sprite && (image.meta = meta.sprite);
-                } catch (err) {
-                    log(colors.cyan(basename) + ' > ' + colors.white('Can not parse meta json for ' + url) + ': "' + colors.red(err) + '"');
-                }
-            }
+			image.path = filePath;
 
-            if (options.retina && (retina = retinaRegex.exec(url))) {
-                image.isRetina = true;
-                image.retinaRatio = retina[1];
-            }
+			// reset lastIndex
+			[httpRegex, imagePathRegex, retinaRegex, filePathRegex].forEach(function(regex) {
+				regex.lastIndex = 0;
+			});
 
-            filePath = filePathRegex.exec(url)[0].replace(/['"]/g, '');
+			images.push(image);
+		}
 
-            // if url to image is relative
-            if(filePath.charAt(0) === "/") {
-                filePath = path.resolve(options.baseUrl + filePath);
-            } else {
-                filePath = path.resolve(file.path.substring(0, file.path.lastIndexOf(path.sep)), filePath);
-            }
+		// reset lastIndex
+		imageRegex.lastIndex = 0;
 
-            image.path = filePath;
+		// remove nulls and duplicates
+		images = _.uniq(_.filter(images), function(image) {
+			return image.path;
+		});
 
-            // reset lastIndex
-            [httpRegex, pngRegex, retinaRegex, filePathRegex].forEach(function(regex) {
-                regex.lastIndex = 0;
-            });
-
-            images.push(image);
-        }
-
-        // reset lastIndex
-        imageRegex.lastIndex = 0;
-
-        // remove nulls and duplicates
-        images = _.chain(images)
-            .filter()
-            .unique(function(image) {
-                return image.path;
-            })
-            .value();
-
-        return Q(images)
-            // apply user filters
-            .then(function(images) {
-                return Q.Promise(function(resolve, reject) {
-                    async.reduce(
-                        options.filter,
-                        images,
-                        function(images, filter, next) {
-                            async.filter(
-                                images,
-                                function(image, ok) {
-                                    Q(filter(image)).then(ok);
-                                },
-                                function(images) {
-                                    next(null, images);
-                                }
-                            );
-                        },
-                        function(err, images) {
-                            if (err) {
-                                return reject(err);
-                            }
-
-                            resolve(images);
-                        }
-                    );
-                });
-            })
-            // apply user group processors
-            .then(function(images) {
-                return Q.Promise(function(resolve, reject) {
-                    async.reduce(
-                        options.groupBy,
-                        images,
-                        function(images, groupBy, next) {
-                            async.map(images, function(image, done) {
-                                Q(groupBy(image))
-                                    .then(function(group) {
-                                        if (group) {
-                                            image.group.push(group);
-                                        }
-
-                                        done(null, image);
-                                    })
-                                    .catch(done);
-                            }, next);
-                        },
-                        function(err, images) {
-                            if (err) {
-                                return reject(err);
-                            }
-
-                            resolve(images);
-                        }
-                    );
-                });
-            });
-    }
+		return Promise.resolve(images)
+			// apply user filters
+			.then(function(images) {
+				return new Promise(function(resolve, reject) {
+					async.filter(images, function(image, callback) {
+						async.reduce(options.filter, true, function(status, filter, callback) {
+							if (!status) return callback(null, false);
+							Promise.resolve(filter(image))
+								.then(function(status) { callback(null, status); })
+								.catch(callback);
+						}, callback);
+					}, function(err, filteredImages) {
+						if (err) return reject(err);
+						resolve(filteredImages);
+					});
+				});
+			})
+			// apply user group processors
+			.then(function(images) {
+				return new Promise(function(resolve, reject) {
+					async.reduce(
+						options.groupBy,
+						images,
+						function(images, groupBy, next) {
+							async.map(images, function(image, done) {
+								Promise.resolve(groupBy(image))
+									.then(function(group) {
+										if (group) image.group.push(group);
+										done(null, image);
+									})
+									.catch(done);
+							}, next);
+						},
+						function(err, images) {
+							if (err) return reject(err);
+							resolve(images);
+						}
+					);
+				});
+			});
+	}
 })();
 
 var callSpriteSmithWith = (function() {
-    var GROUP_DELIMITER = ".",
-        GROUP_MASK = "*";
+	var GROUP_DELIMITER = ".", GROUP_MASK = "*";
 
-    // helper function to minimize user group names symbols collisions
-    function mask(toggle) {
-        var from, to;
+	// helper function to minimize user group names symbols collisions
+	function mask(toggle) {
+		var from = new RegExp("[" + (toggle ? GROUP_DELIMITER : GROUP_MASK) + "]", "gi");
+		var to = toggle ? GROUP_MASK : GROUP_DELIMITER;
+		return function(value) {
+			return value.replace(from, to);
+		}
+	}
 
-        from = new RegExp("[" + (toggle ? GROUP_DELIMITER : GROUP_MASK) + "]", "gi");
-        to = toggle ? GROUP_MASK : GROUP_DELIMITER;
+	return function(images, options) {
+		var all = _.chain(images)
+			.groupBy(function(image) {
+				var tmp = image.group.map(mask(true));
+				tmp.unshift('_');
+				return tmp.join(GROUP_DELIMITER);
+			})
+			.map(function(images, tmp) {
+				var config = _.merge({}, options, {
+					src: images.map(function(image) {
+						return image.path;
+					})
+				});
 
-        return function(value) {
-            return value.replace(from, to);
-        }
-    }
+				// enlarge padding, if its retina
+				if (_.every(images, function(image) { return image.isRetina; })) {
+					var ratio = _.chain(images).flatten('retinaRatio').uniq().value();
+					if (ratio.length === 1) {
+						config.padding = config.padding * ratio[0];
+					}
+				}
 
-    return function(images, options) {
-        var all;
+				// validate config
+				try { new Spritesmith(config); }
+				catch (e) { return Promise.reject(e);}
 
-        all = _.chain(images)
-            .groupBy(function(image) {
-                var tmp;
+				return new Promise(function(resolve, reject) {
+					Spritesmith.run(config, function(err, result) {
+						if (err) return reject(err);
+						tmp = tmp.split(GROUP_DELIMITER);
+						tmp.shift();
+						// append info about sprite group
+						result.group = tmp.map(mask(false));
+						resolve(result);
+					});
+				});
+			})
+			.value();
 
-                tmp = image.group.map(mask(true));
-                tmp.unshift('_');
-
-                return tmp.join(GROUP_DELIMITER);
-            })
-            .map(function(images, tmp) {
-                var config, ratio;
-
-                config = _.merge({}, options, {
-                    src: _.pluck(images, 'path')
-                });
-
-                // enlarge padding, if its retina
-                if (_.every(images, function(image) {return image.isRetina})) {
-                    ratio = _.chain(images).flatten('retinaRatio').unique().value();
-                    if (ratio.length == 1) {
-                        config.padding = config.padding * ratio[0];
-                    }
-                }
-
-                return Q.nfcall(spritesmith, config).then(function(result) {
-                    tmp = tmp.split(GROUP_DELIMITER);
-                    tmp.shift();
-
-                    // append info about sprite group
-                    result.group = tmp.map(mask(false));
-
-                    return result;
-                });
-            })
-            .value();
-
-
-        return Q.all(all).then(function(results) {
-            debug.images+= images.length;
-            debug.sprites+= results.length;
-            return results;
-        });
-    }
+		return Promise.all(all).then(function(results) {
+			debug.images += images.length;
+			debug.sprites += results.length;
+			return Promise.resolve(results);
+		});
+	}
 })();
 
 var updateReferencesIn = (function() {
-    var template;
+	var template;
 
-    template = _.template(
-        'background-image: url("<%= spriteSheetPath %>");\n    ' +
-        'background-position: -<%= isRetina ? (coordinates.x / retinaRatio) : coordinates.x %>px -<%= isRetina ? (coordinates.y / retinaRatio) : coordinates.y %>px;\n    ' +
-        'background-size: <%= isRetina ? (properties.width / retinaRatio) : properties.width %>px <%= isRetina ? (properties.height / retinaRatio) : properties.height %>px!important;'
-    );
+	template = _.template(
+		'background-image: url("<%= spriteSheetPath %>");\n	' +
+		'background-position: -<%= isRetina ? (coordinates.x / retinaRatio) : coordinates.x %>px -<%= isRetina ? (coordinates.y / retinaRatio) : coordinates.y %>px;\n	' +
+		'background-size: <%= isRetina ? (properties.width / retinaRatio) : properties.width %>px <%= isRetina ? (properties.height / retinaRatio) : properties.height %>px!important;'
+	);
 
-    return function(file) {
-        var content = file.contents.toString();
+	return function(file) {
+		var content = file.contents.toString();
 
-        return function(results) {
-            results.forEach(function(images) {
-                images.forEach(function(image) {
-                    content = content.replace(image.replacement, template(image));
-                });
-            });
+		return function(results) {
+			results.forEach(function(images) {
+				images.forEach(function(image) {
+					content = content.replace(image.replacement, template(image));
+				});
+			});
 
-            return Q(content);
-        }
-    }
+			return Promise.resolve(content);
+		}
+	}
 })();
 
 var exportSprites = (function() {
-    function makeSpriteSheetPath(spriteSheetName, group) {
-        var path;
+	function makeSpriteSheetPath(spriteSheetName, group) {
+		group = group || [];
+		if (group.length == 0) return spriteSheetName;
+		var path = spriteSheetName.split('.');
+		Array.prototype.splice.apply(path, [path.length - 1, 0].concat(group));
+		return path.join('.');
+	}
 
-        group || (group = []);
+	return function(stream, options) {
+		return function(results) {
+			results = results.map(function(result) {
+				result.path = makeSpriteSheetPath(options.spriteSheetName, result.group);
+				var sprite = new File({
+					path: result.path,
+					contents: new Buffer(result.image, 'binary')
+				});
 
-        if (group.length == 0) {
-            return spriteSheetName;
-        }
+				stream.push(sprite);
+				options.verbose && log('Spritesheet "' + result.path + '" created');
+				return result;
+			});
 
-        path = spriteSheetName.split('.');
-        Array.prototype.splice.apply(path, [path.length - 1, 0].concat(group));
-
-        return path.join('.');
-    }
-
-    return function(stream, options) {
-        return function(results) {
-            results = results.map(function(result) {
-                var sprite;
-
-                result.path = makeSpriteSheetPath(options.spriteSheetName, result.group);
-
-                sprite = new File({
-                    path: result.path,
-                    contents: new Buffer(result.image, 'binary')
-                });
-
-                stream.push(sprite);
-
-                options.verbose && log('Spritesheet', result.path, 'has been created');
-
-
-                return result;
-            });            
-
-            return results;
-        }
-    }
+			return results;
+		}
+	}
 })();
 
 var exportStylesheet = function(stream, options) {
-    return function(content) {
-        var stylesheet;
+	return function(content) {
+		var stylesheet;
 
-        stylesheet = new File({
-            path: options.styleSheetName,
-            contents: new Buffer(content)
-        });
+		stylesheet = new File({
+			path: options.styleSheetName,
+			contents: new Buffer(content)
+		});
 
-        stream.push(stylesheet);
+		stream.push(stylesheet);
 
-        options.verbose && log('Stylesheet', options.styleSheetName, 'has been created');
-    }
+		options.verbose && log('Stylesheet "' + options.styleSheetName + '" created');
+	}
 };
 
 var mapSpritesProperties = function(images, options) {
-    return function(results) {
-        return results.map(function(result) {
-            return _.map(result.coordinates, function(coordinates, path) {
-                return _.merge(_.find(images, {path: path}), {
-                    coordinates: coordinates,
-                    spriteSheetPath: options.spriteSheetPath ? options.spriteSheetPath + "/" + result.path : result.path,
-                    properties: result.properties
-                });
-            });
-        });
-    }
+	return function(results) {
+		return results.map(function(result) {
+			return _.map(result.coordinates, function(coordinates, path) {
+				return _.merge(_.find(images, {path: path}), {
+					coordinates: coordinates,
+					spriteSheetPath: options.spriteSheetPath ? options.spriteSheetPath + "/" + result.path : result.path,
+					properties: result.properties
+				});
+			});
+		});
+	}
 };
 
-module.exports = function(options) { 'use strict';
-    var stream, styleSheetStream, spriteSheetStream;
+module.exports = function(options) {
+	var stream, styleSheetStream, spriteSheetStream;
 
-    debug = {
-        sprites: 0,
-        images:  0
-    };
+	debug = {
+		sprites: 0,
+		images:	0
+	};
 
-    options = _.merge({
-        src:        [],
-        engine:     "pngsmith", //auto
-        algorithm:  "top-down",
-        padding:    0,
-        engineOpts: {},
-        exportOpts: {
+	options = _.merge({
+		src: [],
+		engine: null, // auto
+		algorithm: "top-down",
+		padding: 0,
+		engineOpts: {},
+		exportOpts: {},
+		imgOpts: {
+			timeout: 30000
+		},
+		baseUrl: './',
+		retina: true,
+		styleSheetName: null,
+		spriteSheetName: null,
+		spriteSheetPath: null,
+		filter: [],
+		groupBy: [],
+		accumulate: false,
+		verbose: false
+	}, options || {});
 
-        },
-        imgOpts: {
-            timeout: 30000
-        },
+	options.verbose = true;
 
-        baseUrl:         './',
-        retina:          true,
-        styleSheetName:  null,
-        spriteSheetName: null,
-        spriteSheetPath: null,
-        filter:          [],
-        groupBy:         [],
-        accumulate:      false,
-        verbose:         false
-    }, options || {});
+	// check necessary properties
+	['spriteSheetName'].forEach(function(property) {
+		if (!options[property]) {
+			throw new gutil.PluginError(PLUGIN_NAME, '`' + property + '` is required');
+		}
+	});
 
-    // check necessary properties
-    ['spriteSheetName'].forEach(function(property) {
-        if (!options[property]) {
-            throw new gutil.PluginError(PLUGIN_NAME, '`' + property + '` is required');
-        }
-    });
+	// prepare filters
+	if (typeof options.filter === 'function') {
+		options.filter = [options.filter]
+	}
 
-    // prepare filters
-    if (_.isFunction(options.filter)) {
-        options.filter = [options.filter]
-    }
+	// prepare groupers
+	if (typeof options.groupBy === 'function') {
+		options.groupBy = [options.groupBy]
+	}
 
-    // prepare groupers
-    if (_.isFunction(options.groupBy)) {
-        options.groupBy = [options.groupBy]
-    }
+	// add meta skip filter
+	options.filter.unshift(function(image) {
+		image.meta.skip && options.verbose && log(image.path + ' skipped as it meta declares to skip');
+		return !image.meta.skip;
+	});
 
-    // add meta skip filter
-    options.filter.unshift(function(image) {
-        image.meta.skip && options.verbose && log(image.path + ' has been skipped as it meta declares to skip');
-        return !image.meta.skip;
-    });
+	// add not existing filter
+	options.filter.push(function(image) {
+		return new Promise(function(resolve, reject) {
+			fs.exists(image.path, function(exists) {
+				!exists && options.verbose && log(image.path + ' skipped as it does not exist!');
+				resolve(exists);
+			});
+		});
+	});
 
-    // add not existing filter
-    options.filter.push(function(image) {
-        var deferred = Q.defer();
+	// add retina grouper if needed
+	if (options.retina) {
+		options.groupBy.unshift(function(image) {
+			if (image.isRetina) {
+				return "@" + image.retinaRatio + "x";
+			}
 
-        fs.exists(image.path, function(exists) {
-            !exists && options.verbose && log(image.path + ' has been skipped as it does not exist!');
-            deferred.resolve(exists);
-        });
+			return null;
+		});
+	}
 
-        return deferred.promise;
-    });
+	// create output streams
+	styleSheetStream = through2({objectMode: true});
+	spriteSheetStream = through2({objectMode: true});
 
-    // add retina grouper if needed
-    if (options.retina) {
-        options.groupBy.unshift(function(image) {
-            if (image.isRetina) {
-                return "@" + image.retinaRatio + "x";
-            }
+	var accumulatedFiles = [];
 
-            return null;
-        });
-    }
+	stream = through2({objectMode: true},
+		function(file, enc, done) {
+			if (file.isNull()) {
+				this.push(file); // Do nothing if no contents
+				return done();
+			}
 
-    // create output streams
-    function noop(){}
-    styleSheetStream = new Readable({objectMode: true});
-    spriteSheetStream = new Readable({objectMode: true});
-    spriteSheetStream._read = styleSheetStream._read = noop;
+			if (file.isStream()) {
+				this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streams is not supported!'));
+				return done();
+			}
 
-    var accumulatedFiles = [];
+			if (file.isBuffer()) {
+				// postpone evaluation, if we are accumulating
+				if (options.accumulate) {
+					accumulatedFiles.push(file);
+					stream.push(file);
+					done();
+					return;
+				}
+				getImages(file, options).then(function(images) {
+					callSpriteSmithWith(images, options)
+						.then(exportSprites(spriteSheetStream, options))
+						.then(mapSpritesProperties(images, options))
+						.then(updateReferencesIn(file))
+						.then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: options.styleSheetName || path.basename(file.path) })))
+						.then(function() {
+							// pipe source file
+							stream.push(file);
+							done();
+						})
+						.catch(function(err) {
+							stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+							done();
+						});
+				}).catch(function(err) {
+					stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+					done();
+				});
 
-    stream = through.obj(
-        function(file, enc, done) {
-            if (file.isNull()) {
-                this.push(file); // Do nothing if no contents
-                return done();
-            }
+				return null;
+			} else {
+				this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Something went wrong!'));
+				return done();
+			}
+		},
+		// flush
+		function(done) {
+			var pending;
 
-            if (file.isStream()) {
-                this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streams is not supported!'));
-                return done();
-            }
+			if (options.accumulate) {
+				pending = Promise
+					.all(accumulatedFiles.map(function(file) {
+						return getImages(file, options);
+					}))
+					.then(function(list) {
+						var images;
 
-            if (file.isBuffer()) {
-                // postpone evaluation, if we accumulating
-                if (options.accumulate) {
-                    accumulatedFiles.push(file);
-                    stream.push(file);
-                    done();
-                    return;
-                }
+						return _.chain(list)
+							.reduce(function(images, portion) {
+								return images.concat(portion);
+							}, [])
+							.uniq(function(image) {
+								return image.path;
+							})
+							.value();
+					})
+					.then(function(images) {
+						return callSpriteSmithWith(images, options)
+							.then(exportSprites(spriteSheetStream, options))
+							.then(mapSpritesProperties(images, options))
+							.then(function(results) {
+								return Promise.all(accumulatedFiles.map(function(file) {
+									return updateReferencesIn(file)(results)
+										.then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: path.basename(file.path) })));
+								}));
+							});
+					})
+					.catch(function(err) {
+						stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+						done();
+					});
+			} else {
+				pending = Promise.resolve();
+			}
 
-                getImages(file, options)
-                    .then(function(images) {
-                        callSpriteSmithWith(images, options)
-                            .then(exportSprites(spriteSheetStream, options))
-                            .then(mapSpritesProperties(images, options))
-                            .then(updateReferencesIn(file))
-                            .then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: options.styleSheetName || path.basename(file.path) })))
-                            .then(function() {
-                                // pipe source file
-                                stream.push(file);
-                                done();
-                            })
-                            .catch(function(err) {
-                                stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
-                                done();
-                            });
-                    });
+			pending.then(function() {
+				// end streams
+				styleSheetStream.push(null);
+				spriteSheetStream.push(null);
+				log(util.format("Created %d sprite(s) from %d images, saved %s% requests", debug.sprites, debug.images, debug.images > 0 ? ((debug.sprites / debug.images) * 100).toFixed(1) : 0));
+				done();
+			});
+		}
+	);
 
+	stream.css = styleSheetStream;
+	stream.img = spriteSheetStream;
 
-                return null;
-            } else {
-                this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Something went wrong!'));
-                return done();
-            }
-        },
-        // flush
-        function(done) {
-            var pending;
-
-            if (options.accumulate) {
-                pending = Q
-                    .all(accumulatedFiles.map(function(file) {
-                        return getImages(file, options);
-                    }))
-                    .then(function(list) {
-                        var images;
-
-                        return _.chain(list)
-                            .reduce(function(images, portion) {
-                                return images.concat(portion);
-                            }, [])
-                            .unique(function(image) {
-                                return image.path;
-                            })
-                            .value();
-                    })
-                    .then(function(images) {
-                        return callSpriteSmithWith(images, options)
-                            .then(exportSprites(spriteSheetStream, options))
-                            .then(mapSpritesProperties(images, options))
-                            .then(function(results) {
-                                return Q.all(accumulatedFiles.map(function(file) {
-                                    return updateReferencesIn(file)(results)
-                                        .then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: path.basename(file.path) })));
-                                }));
-                            });
-                    })
-                    .catch(function(err) {
-                        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
-                        done();
-                    });
-            } else {
-                pending = Q();
-            }
-
-            pending.then(function() {
-                // end streams
-                styleSheetStream.push(null);
-                spriteSheetStream.push(null);
-
-                log(util.format("Created %d sprite(s) from %d images, saved %s% requests", debug.sprites, debug.images, debug.images > 0 ? ((debug.sprites / debug.images) * 100).toFixed(1) : 0));
-
-                done();
-            });
-        }
-    );
-
-    stream.css = styleSheetStream;
-    stream.img = spriteSheetStream;
-
-    return stream;
+	return stream;
 };

--- a/index.js
+++ b/index.js
@@ -15,462 +15,462 @@ var PLUGIN_NAME = 'gulp-sprite-generator';
 var debug;
 
 function log() {
-	var args = Array.prototype.slice.call(arguments);
-	var sig = '[' + colors.green(PLUGIN_NAME) + ']';
-	args.unshift(sig);
-	gutil.log.apply(gutil, args);
+    var args = Array.prototype.slice.call(arguments);
+    var sig = '[' + colors.green(PLUGIN_NAME) + ']';
+    args.unshift(sig);
+    gutil.log.apply(gutil, args);
 }
 
 var getImages = (function() {
-	var imageRegex     = new RegExp('background-image\s*:[\\s]?url\\(["\']?([\\w\\d\\s!:./\\-\\_@]*\\.[\\w?#]+)["\']?\\)[^;]*\\;(?:\\s*\\/\\*\\s*@meta\\s*(\\{.*\\})\\s*\\*\\/)?', 'ig');
-	var retinaRegex    = new RegExp('@(\\d)x\\.[a-z]{3,4}$', 'ig');
-	var httpRegex      = new RegExp('https?', 'ig');
-	var imagePathRegex = new RegExp('\\.(png|jpe?g)$', 'ig');
-	var filePathRegex  = new RegExp('["\']?([\\w\\d\\s! :./\\-\\_@]*\\.[\\w?#]+)["\']?', 'ig');
+    var imageRegex     = new RegExp('background-image\s*:[\\s]?url\\(["\']?([\\w\\d\\s!:./\\-\\_@]*\\.[\\w?#]+)["\']?\\)[^;]*\\;(?:\\s*\\/\\*\\s*@meta\\s*(\\{.*\\})\\s*\\*\\/)?', 'ig');
+    var retinaRegex    = new RegExp('@(\\d)x\\.[a-z]{3,4}$', 'ig');
+    var httpRegex      = new RegExp('https?', 'ig');
+    var imagePathRegex = new RegExp('\\.(png|jpe?g)$', 'ig');
+    var filePathRegex  = new RegExp('["\']?([\\w\\d\\s! :./\\-\\_@]*\\.[\\w?#]+)["\']?', 'ig');
 
-	return function(file, options) {
-		var reference, images,
-			retina, filePath,
-			url, image, meta, basename,
-			makeRegexp, content;
+    return function(file, options) {
+        var reference, images,
+            retina, filePath,
+            url, image, meta, basename,
+            makeRegexp, content;
 
-		images = [];
-		content = file.contents.toString();
-		basename = path.basename(file.path);
+        images = [];
+        content = file.contents.toString();
+        basename = path.basename(file.path);
 
-		makeRegexp = (function() {
-			var matchOperatorsRe = /[|\\/{}()[\]^$+*?.]/g;
-			return function(str) {
-				return str.replace(matchOperatorsRe,	'\\$&');
-			}
-		})();
+        makeRegexp = (function() {
+            var matchOperatorsRe = /[|\\/{}()[\]^$+*?.]/g;
+            return function(str) {
+                return str.replace(matchOperatorsRe,    '\\$&');
+            }
+        })();
 
-		while ((reference = imageRegex.exec(content)) != null) {
-			url	 = reference[1];
-			meta	= reference[2];
+        while ((reference = imageRegex.exec(content)) != null) {
+            url     = reference[1];
+            meta    = reference[2];
 
-			image = {
-				replacement: new RegExp('background-image:\\s+url\\(\\s?(["\']?)\\s?' + makeRegexp(url) + '\\s?\\1\\s?\\)[^;]*\\;', 'gi'),
-				url: url,
-				group: [],
-				isRetina:	false,
-				retinaRatio: 1,
-				meta: {}
-			};
+            image = {
+                replacement: new RegExp('background-image:\\s+url\\(\\s?(["\']?)\\s?' + makeRegexp(url) + '\\s?\\1\\s?\\)[^;]*\\;', 'gi'),
+                url: url,
+                group: [],
+                isRetina:    false,
+                retinaRatio: 1,
+                meta: {}
+            };
 
-			if (httpRegex.test(url)) {
-				options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s an external resource');
-				continue;
-			}
+            if (httpRegex.test(url)) {
+                options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s an external resource');
+                continue;
+            }
 
-			if (!imagePathRegex.test(url)) {
-				options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s not a png or jpeg');
-				continue;
-			}
+            if (!imagePathRegex.test(url)) {
+                options.verbose && log(colors.cyan(basename) + ' > ' + url + ' skipped as it\'s not a png or jpeg');
+                continue;
+            }
 
-			if (meta) {
-				try {
-					meta = JSON.parse(meta);
-					meta.sprite && (image.meta = meta.sprite);
-				} catch (err) {
-					log(colors.cyan(basename) + ' > ' + colors.white('Can not parse meta json for ' + url) + ': "' + colors.red(err) + '"');
-				}
-			}
+            if (meta) {
+                try {
+                    meta = JSON.parse(meta);
+                    meta.sprite && (image.meta = meta.sprite);
+                } catch (err) {
+                    log(colors.cyan(basename) + ' > ' + colors.white('Can not parse meta json for ' + url) + ': "' + colors.red(err) + '"');
+                }
+            }
 
-			if (options.retina && (retina = retinaRegex.exec(url))) {
-				image.isRetina = true;
-				image.retinaRatio = retina[1];
-			}
+            if (options.retina && (retina = retinaRegex.exec(url))) {
+                image.isRetina = true;
+                image.retinaRatio = retina[1];
+            }
 
-			filePath = filePathRegex.exec(url)[0].replace(/['"]/g, '');
+            filePath = filePathRegex.exec(url)[0].replace(/['"]/g, '');
 
-			// if url to image is relative
-			if(filePath.charAt(0) === "/") {
-				filePath = path.resolve(options.baseUrl + filePath);
-			} else {
-				filePath = path.resolve(file.path.substring(0, file.path.lastIndexOf(path.sep)), filePath);
-			}
+            // if url to image is relative
+            if(filePath.charAt(0) === "/") {
+                filePath = path.resolve(options.baseUrl + filePath);
+            } else {
+                filePath = path.resolve(file.path.substring(0, file.path.lastIndexOf(path.sep)), filePath);
+            }
 
-			image.path = filePath;
+            image.path = filePath;
 
-			// reset lastIndex
-			[httpRegex, imagePathRegex, retinaRegex, filePathRegex].forEach(function(regex) {
-				regex.lastIndex = 0;
-			});
+            // reset lastIndex
+            [httpRegex, imagePathRegex, retinaRegex, filePathRegex].forEach(function(regex) {
+                regex.lastIndex = 0;
+            });
 
-			images.push(image);
-		}
+            images.push(image);
+        }
 
-		// reset lastIndex
-		imageRegex.lastIndex = 0;
+        // reset lastIndex
+        imageRegex.lastIndex = 0;
 
-		// remove nulls and duplicates
-		images = _.uniq(_.filter(images), function(image) {
-			return image.path;
-		});
+        // remove nulls and duplicates
+        images = _.uniq(_.filter(images), function(image) {
+            return image.path;
+        });
 
-		return Promise.resolve(images)
-			// apply user filters
-			.then(function(images) {
-				return new Promise(function(resolve, reject) {
-					async.filter(images, function(image, callback) {
-						async.reduce(options.filter, true, function(status, filter, callback) {
-							if (!status) return callback(null, false);
-							Promise.resolve(filter(image))
-								.then(function(status) { callback(null, status); })
-								.catch(callback);
-						}, callback);
-					}, function(err, filteredImages) {
-						if (err) return reject(err);
-						resolve(filteredImages);
-					});
-				});
-			})
-			// apply user group processors
-			.then(function(images) {
-				return new Promise(function(resolve, reject) {
-					async.reduce(
-						options.groupBy,
-						images,
-						function(images, groupBy, next) {
-							async.map(images, function(image, done) {
-								Promise.resolve(groupBy(image))
-									.then(function(group) {
-										if (group) image.group.push(group);
-										done(null, image);
-									})
-									.catch(done);
-							}, next);
-						},
-						function(err, images) {
-							if (err) return reject(err);
-							resolve(images);
-						}
-					);
-				});
-			});
-	}
+        return Promise.resolve(images)
+            // apply user filters
+            .then(function(images) {
+                return new Promise(function(resolve, reject) {
+                    async.filter(images, function(image, callback) {
+                        async.reduce(options.filter, true, function(status, filter, callback) {
+                            if (!status) return callback(null, false);
+                            Promise.resolve(filter(image))
+                                .then(function(status) { callback(null, status); })
+                                .catch(callback);
+                        }, callback);
+                    }, function(err, filteredImages) {
+                        if (err) return reject(err);
+                        resolve(filteredImages);
+                    });
+                });
+            })
+            // apply user group processors
+            .then(function(images) {
+                return new Promise(function(resolve, reject) {
+                    async.reduce(
+                        options.groupBy,
+                        images,
+                        function(images, groupBy, next) {
+                            async.map(images, function(image, done) {
+                                Promise.resolve(groupBy(image))
+                                    .then(function(group) {
+                                        if (group) image.group.push(group);
+                                        done(null, image);
+                                    })
+                                    .catch(done);
+                            }, next);
+                        },
+                        function(err, images) {
+                            if (err) return reject(err);
+                            resolve(images);
+                        }
+                    );
+                });
+            });
+    }
 })();
 
 var callSpriteSmithWith = (function() {
-	var GROUP_DELIMITER = ".", GROUP_MASK = "*";
+    var GROUP_DELIMITER = ".", GROUP_MASK = "*";
 
-	// helper function to minimize user group names symbols collisions
-	function mask(toggle) {
-		var from = new RegExp("[" + (toggle ? GROUP_DELIMITER : GROUP_MASK) + "]", "gi");
-		var to = toggle ? GROUP_MASK : GROUP_DELIMITER;
-		return function(value) {
-			return value.replace(from, to);
-		}
-	}
+    // helper function to minimize user group names symbols collisions
+    function mask(toggle) {
+        var from = new RegExp("[" + (toggle ? GROUP_DELIMITER : GROUP_MASK) + "]", "gi");
+        var to = toggle ? GROUP_MASK : GROUP_DELIMITER;
+        return function(value) {
+            return value.replace(from, to);
+        }
+    }
 
-	return function(images, options) {
-		var all = _.chain(images)
-			.groupBy(function(image) {
-				var tmp = image.group.map(mask(true));
-				tmp.unshift('_');
-				return tmp.join(GROUP_DELIMITER);
-			})
-			.map(function(images, tmp) {
-				var config = _.merge({}, options, {
-					src: images.map(function(image) {
-						return image.path;
-					})
-				});
+    return function(images, options) {
+        var all = _.chain(images)
+            .groupBy(function(image) {
+                var tmp = image.group.map(mask(true));
+                tmp.unshift('_');
+                return tmp.join(GROUP_DELIMITER);
+            })
+            .map(function(images, tmp) {
+                var config = _.merge({}, options, {
+                    src: images.map(function(image) {
+                        return image.path;
+                    })
+                });
 
-				// enlarge padding, if its retina
-				if (_.every(images, function(image) { return image.isRetina; })) {
-					var ratio = _.chain(images).flatten('retinaRatio').uniq().value();
-					if (ratio.length === 1) {
-						config.padding = config.padding * ratio[0];
-					}
-				}
+                // enlarge padding, if its retina
+                if (_.every(images, function(image) { return image.isRetina; })) {
+                    var ratio = _.chain(images).flatten('retinaRatio').uniq().value();
+                    if (ratio.length === 1) {
+                        config.padding = config.padding * ratio[0];
+                    }
+                }
 
-				// validate config
-				try { new Spritesmith(config); }
-				catch (e) { return Promise.reject(e);}
+                // validate config
+                try { new Spritesmith(config); }
+                catch (e) { return Promise.reject(e);}
 
-				return new Promise(function(resolve, reject) {
-					Spritesmith.run(config, function(err, result) {
-						if (err) return reject(err);
-						tmp = tmp.split(GROUP_DELIMITER);
-						tmp.shift();
-						// append info about sprite group
-						result.group = tmp.map(mask(false));
-						resolve(result);
-					});
-				});
-			})
-			.value();
+                return new Promise(function(resolve, reject) {
+                    Spritesmith.run(config, function(err, result) {
+                        if (err) return reject(err);
+                        tmp = tmp.split(GROUP_DELIMITER);
+                        tmp.shift();
+                        // append info about sprite group
+                        result.group = tmp.map(mask(false));
+                        resolve(result);
+                    });
+                });
+            })
+            .value();
 
-		return Promise.all(all).then(function(results) {
-			debug.images += images.length;
-			debug.sprites += results.length;
-			return Promise.resolve(results);
-		});
-	}
+        return Promise.all(all).then(function(results) {
+            debug.images += images.length;
+            debug.sprites += results.length;
+            return Promise.resolve(results);
+        });
+    }
 })();
 
 var updateReferencesIn = (function() {
-	var template;
+    var template;
 
-	template = _.template(
-		'background-image: url("<%= spriteSheetPath %>");\n	' +
-		'background-position: -<%= isRetina ? (coordinates.x / retinaRatio) : coordinates.x %>px -<%= isRetina ? (coordinates.y / retinaRatio) : coordinates.y %>px;\n	' +
-		'background-size: <%= isRetina ? (properties.width / retinaRatio) : properties.width %>px <%= isRetina ? (properties.height / retinaRatio) : properties.height %>px!important;'
-	);
+    template = _.template(
+        'background-image: url("<%= spriteSheetPath %>");\n    ' +
+        'background-position: -<%= isRetina ? (coordinates.x / retinaRatio) : coordinates.x %>px -<%= isRetina ? (coordinates.y / retinaRatio) : coordinates.y %>px;\n    ' +
+        'background-size: <%= isRetina ? (properties.width / retinaRatio) : properties.width %>px <%= isRetina ? (properties.height / retinaRatio) : properties.height %>px!important;'
+    );
 
-	return function(file) {
-		var content = file.contents.toString();
+    return function(file) {
+        var content = file.contents.toString();
 
-		return function(results) {
-			results.forEach(function(images) {
-				images.forEach(function(image) {
-					content = content.replace(image.replacement, template(image));
-				});
-			});
+        return function(results) {
+            results.forEach(function(images) {
+                images.forEach(function(image) {
+                    content = content.replace(image.replacement, template(image));
+                });
+            });
 
-			return Promise.resolve(content);
-		}
-	}
+            return Promise.resolve(content);
+        }
+    }
 })();
 
 var exportSprites = (function() {
-	function makeSpriteSheetPath(spriteSheetName, group) {
-		group = group || [];
-		if (group.length == 0) return spriteSheetName;
-		var path = spriteSheetName.split('.');
-		Array.prototype.splice.apply(path, [path.length - 1, 0].concat(group));
-		return path.join('.');
-	}
+    function makeSpriteSheetPath(spriteSheetName, group) {
+        group = group || [];
+        if (group.length == 0) return spriteSheetName;
+        var path = spriteSheetName.split('.');
+        Array.prototype.splice.apply(path, [path.length - 1, 0].concat(group));
+        return path.join('.');
+    }
 
-	return function(stream, options) {
-		return function(results) {
-			results = results.map(function(result) {
-				result.path = makeSpriteSheetPath(options.spriteSheetName, result.group);
-				var sprite = new File({
-					path: result.path,
-					contents: new Buffer(result.image, 'binary')
-				});
+    return function(stream, options) {
+        return function(results) {
+            results = results.map(function(result) {
+                result.path = makeSpriteSheetPath(options.spriteSheetName, result.group);
+                var sprite = new File({
+                    path: result.path,
+                    contents: new Buffer(result.image, 'binary')
+                });
 
-				stream.push(sprite);
-				options.verbose && log('Spritesheet "' + result.path + '" created');
-				return result;
-			});
+                stream.push(sprite);
+                options.verbose && log('Spritesheet "' + result.path + '" created');
+                return result;
+            });
 
-			return results;
-		}
-	}
+            return results;
+        }
+    }
 })();
 
 var exportStylesheet = function(stream, options) {
-	return function(content) {
-		var stylesheet;
+    return function(content) {
+        var stylesheet;
 
-		stylesheet = new File({
-			path: options.styleSheetName,
-			contents: new Buffer(content)
-		});
+        stylesheet = new File({
+            path: options.styleSheetName,
+            contents: new Buffer(content)
+        });
 
-		stream.push(stylesheet);
+        stream.push(stylesheet);
 
-		options.verbose && log('Stylesheet "' + options.styleSheetName + '" created');
-	}
+        options.verbose && log('Stylesheet "' + options.styleSheetName + '" created');
+    }
 };
 
 var mapSpritesProperties = function(images, options) {
-	return function(results) {
-		return results.map(function(result) {
-			return _.map(result.coordinates, function(coordinates, path) {
-				return _.merge(_.find(images, {path: path}), {
-					coordinates: coordinates,
-					spriteSheetPath: options.spriteSheetPath ? options.spriteSheetPath + "/" + result.path : result.path,
-					properties: result.properties
-				});
-			});
-		});
-	}
+    return function(results) {
+        return results.map(function(result) {
+            return _.map(result.coordinates, function(coordinates, path) {
+                return _.merge(_.find(images, {path: path}), {
+                    coordinates: coordinates,
+                    spriteSheetPath: options.spriteSheetPath ? options.spriteSheetPath + "/" + result.path : result.path,
+                    properties: result.properties
+                });
+            });
+        });
+    }
 };
 
 module.exports = function(options) {
-	var stream, styleSheetStream, spriteSheetStream;
+    var stream, styleSheetStream, spriteSheetStream;
 
-	debug = {
-		sprites: 0,
-		images:	0
-	};
+    debug = {
+        sprites: 0,
+        images:    0
+    };
 
-	options = _.merge({
-		src: [],
-		engine: null, // auto
-		algorithm: "top-down",
-		padding: 0,
-		engineOpts: {},
-		exportOpts: {},
-		imgOpts: {
-			timeout: 30000
-		},
-		baseUrl: './',
-		retina: true,
-		styleSheetName: null,
-		spriteSheetName: null,
-		spriteSheetPath: null,
-		filter: [],
-		groupBy: [],
-		accumulate: false,
-		verbose: false
-	}, options || {});
+    options = _.merge({
+        src: [],
+        engine: null, // auto
+        algorithm: "top-down",
+        padding: 0,
+        engineOpts: {},
+        exportOpts: {},
+        imgOpts: {
+            timeout: 30000
+        },
+        baseUrl: './',
+        retina: true,
+        styleSheetName: null,
+        spriteSheetName: null,
+        spriteSheetPath: null,
+        filter: [],
+        groupBy: [],
+        accumulate: false,
+        verbose: false
+    }, options || {});
 
-	options.verbose = true;
+    options.verbose = true;
 
-	// check necessary properties
-	['spriteSheetName'].forEach(function(property) {
-		if (!options[property]) {
-			throw new gutil.PluginError(PLUGIN_NAME, '`' + property + '` is required');
-		}
-	});
+    // check necessary properties
+    ['spriteSheetName'].forEach(function(property) {
+        if (!options[property]) {
+            throw new gutil.PluginError(PLUGIN_NAME, '`' + property + '` is required');
+        }
+    });
 
-	// prepare filters
-	if (typeof options.filter === 'function') {
-		options.filter = [options.filter]
-	}
+    // prepare filters
+    if (typeof options.filter === 'function') {
+        options.filter = [options.filter]
+    }
 
-	// prepare groupers
-	if (typeof options.groupBy === 'function') {
-		options.groupBy = [options.groupBy]
-	}
+    // prepare groupers
+    if (typeof options.groupBy === 'function') {
+        options.groupBy = [options.groupBy]
+    }
 
-	// add meta skip filter
-	options.filter.unshift(function(image) {
-		image.meta.skip && options.verbose && log(image.path + ' skipped as it meta declares to skip');
-		return !image.meta.skip;
-	});
+    // add meta skip filter
+    options.filter.unshift(function(image) {
+        image.meta.skip && options.verbose && log(image.path + ' skipped as it meta declares to skip');
+        return !image.meta.skip;
+    });
 
-	// add not existing filter
-	options.filter.push(function(image) {
-		return new Promise(function(resolve, reject) {
-			fs.exists(image.path, function(exists) {
-				!exists && options.verbose && log(image.path + ' skipped as it does not exist!');
-				resolve(exists);
-			});
-		});
-	});
+    // add not existing filter
+    options.filter.push(function(image) {
+        return new Promise(function(resolve, reject) {
+            fs.exists(image.path, function(exists) {
+                !exists && options.verbose && log(image.path + ' skipped as it does not exist!');
+                resolve(exists);
+            });
+        });
+    });
 
-	// add retina grouper if needed
-	if (options.retina) {
-		options.groupBy.unshift(function(image) {
-			if (image.isRetina) {
-				return "@" + image.retinaRatio + "x";
-			}
+    // add retina grouper if needed
+    if (options.retina) {
+        options.groupBy.unshift(function(image) {
+            if (image.isRetina) {
+                return "@" + image.retinaRatio + "x";
+            }
 
-			return null;
-		});
-	}
+            return null;
+        });
+    }
 
-	// create output streams
-	styleSheetStream = through2({objectMode: true});
-	spriteSheetStream = through2({objectMode: true});
+    // create output streams
+    styleSheetStream = through2({objectMode: true});
+    spriteSheetStream = through2({objectMode: true});
 
-	var accumulatedFiles = [];
+    var accumulatedFiles = [];
 
-	stream = through2({objectMode: true},
-		function(file, enc, done) {
-			if (file.isNull()) {
-				this.push(file); // Do nothing if no contents
-				return done();
-			}
+    stream = through2({objectMode: true},
+        function(file, enc, done) {
+            if (file.isNull()) {
+                this.push(file); // Do nothing if no contents
+                return done();
+            }
 
-			if (file.isStream()) {
-				this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streams is not supported!'));
-				return done();
-			}
+            if (file.isStream()) {
+                this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Streams is not supported!'));
+                return done();
+            }
 
-			if (file.isBuffer()) {
-				// postpone evaluation, if we are accumulating
-				if (options.accumulate) {
-					accumulatedFiles.push(file);
-					stream.push(file);
-					done();
-					return;
-				}
-				getImages(file, options).then(function(images) {
-					callSpriteSmithWith(images, options)
-						.then(exportSprites(spriteSheetStream, options))
-						.then(mapSpritesProperties(images, options))
-						.then(updateReferencesIn(file))
-						.then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: options.styleSheetName || path.basename(file.path) })))
-						.then(function() {
-							// pipe source file
-							stream.push(file);
-							done();
-						})
-						.catch(function(err) {
-							stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
-							done();
-						});
-				}).catch(function(err) {
-					stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
-					done();
-				});
+            if (file.isBuffer()) {
+                // postpone evaluation, if we are accumulating
+                if (options.accumulate) {
+                    accumulatedFiles.push(file);
+                    stream.push(file);
+                    done();
+                    return;
+                }
+                getImages(file, options).then(function(images) {
+                    callSpriteSmithWith(images, options)
+                        .then(exportSprites(spriteSheetStream, options))
+                        .then(mapSpritesProperties(images, options))
+                        .then(updateReferencesIn(file))
+                        .then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: options.styleSheetName || path.basename(file.path) })))
+                        .then(function() {
+                            // pipe source file
+                            stream.push(file);
+                            done();
+                        })
+                        .catch(function(err) {
+                            stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+                            done();
+                        });
+                }).catch(function(err) {
+                    stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+                    done();
+                });
 
-				return null;
-			} else {
-				this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Something went wrong!'));
-				return done();
-			}
-		},
-		// flush
-		function(done) {
-			var pending;
+                return null;
+            } else {
+                this.emit('error', new gutil.PluginError(PLUGIN_NAME, 'Something went wrong!'));
+                return done();
+            }
+        },
+        // flush
+        function(done) {
+            var pending;
 
-			if (options.accumulate) {
-				pending = Promise
-					.all(accumulatedFiles.map(function(file) {
-						return getImages(file, options);
-					}))
-					.then(function(list) {
-						var images;
+            if (options.accumulate) {
+                pending = Promise
+                    .all(accumulatedFiles.map(function(file) {
+                        return getImages(file, options);
+                    }))
+                    .then(function(list) {
+                        var images;
 
-						return _.chain(list)
-							.reduce(function(images, portion) {
-								return images.concat(portion);
-							}, [])
-							.uniq(function(image) {
-								return image.path;
-							})
-							.value();
-					})
-					.then(function(images) {
-						return callSpriteSmithWith(images, options)
-							.then(exportSprites(spriteSheetStream, options))
-							.then(mapSpritesProperties(images, options))
-							.then(function(results) {
-								return Promise.all(accumulatedFiles.map(function(file) {
-									return updateReferencesIn(file)(results)
-										.then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: path.basename(file.path) })));
-								}));
-							});
-					})
-					.catch(function(err) {
-						stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
-						done();
-					});
-			} else {
-				pending = Promise.resolve();
-			}
+                        return _.chain(list)
+                            .reduce(function(images, portion) {
+                                return images.concat(portion);
+                            }, [])
+                            .uniq(function(image) {
+                                return image.path;
+                            })
+                            .value();
+                    })
+                    .then(function(images) {
+                        return callSpriteSmithWith(images, options)
+                            .then(exportSprites(spriteSheetStream, options))
+                            .then(mapSpritesProperties(images, options))
+                            .then(function(results) {
+                                return Promise.all(accumulatedFiles.map(function(file) {
+                                    return updateReferencesIn(file)(results)
+                                        .then(exportStylesheet(styleSheetStream, _.extend({}, options, { styleSheetName: path.basename(file.path) })));
+                                }));
+                            });
+                    })
+                    .catch(function(err) {
+                        stream.emit('error', new gutil.PluginError(PLUGIN_NAME, err));
+                        done();
+                    });
+            } else {
+                pending = Promise.resolve();
+            }
 
-			pending.then(function() {
-				// end streams
-				styleSheetStream.push(null);
-				spriteSheetStream.push(null);
-				log(util.format("Created %d sprite(s) from %d images, saved %s% requests", debug.sprites, debug.images, debug.images > 0 ? ((debug.sprites / debug.images) * 100).toFixed(1) : 0));
-				done();
-			});
-		}
-	);
+            pending.then(function() {
+                // end streams
+                styleSheetStream.push(null);
+                spriteSheetStream.push(null);
+                log(util.format("Created %d sprite(s) from %d images, saved %s% requests", debug.sprites, debug.images, debug.images > 0 ? ((debug.sprites / debug.images) * 100).toFixed(1) : 0));
+                done();
+            });
+        }
+    );
 
-	stream.css = styleSheetStream;
-	stream.img = spriteSheetStream;
+    stream.css = styleSheetStream;
+    stream.img = spriteSheetStream;
 
-	return stream;
+    return stream;
 };

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "test": "mocha ./test"
   },
   "dependencies": {
-    "async": "^0.2.10",
-    "colors": "^0.6.2",
-    "gulp-util": "^2.2.14",
-    "lodash": "^2.4.1",
-    "q": "^1.0.1",
-    "spritesmith": "^0.18.0",
-    "through2": "^0.4.1",
-    "vinyl": "^0.2.3"
+    "async": "^2.0.0-rc.3",
+    "colors": "^1.1.2",
+    "es6-promise": "^3.1.2",
+    "gulp-util": "^3.0.7",
+    "lodash": "^4.11.1",
+    "spritesmith": "^3.1.0",
+    "through2": "^2.0.1",
+    "vinyl": "^1.1.1"
   }
 }

--- a/test/expectations/A.css
+++ b/test/expectations/A.css
@@ -1,5 +1,5 @@
 .a {
     background-image: url("sprite.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -0px;
+	background-size: 25px 50px!important;
 }

--- a/test/expectations/B.css
+++ b/test/expectations/B.css
@@ -1,5 +1,5 @@
 .b {
     background-image: url("sprite.png");
-    background-position: -0px -25px;
-    background-size: 25px 50px!important;
+	background-position: -0px -25px;
+	background-size: 25px 50px!important;
 }

--- a/test/expectations/stylesheet.css
+++ b/test/expectations/stylesheet.css
@@ -1,15 +1,15 @@
 .a {
     background-image: url("sprite.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -50px;
+	background-size: 25px 75px!important;
 }
 .b {
     background-image: url("sprite.png");
-    background-position: -0px -25px;
-    background-size: 25px 50px!important;
+	background-position: -0px -25px;
+	background-size: 25px 75px!important;
 }
 .c {
     background-image: url("sprite.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -50px;
+	background-size: 25px 75px!important;
 }

--- a/test/expectations/stylesheet.filter.css
+++ b/test/expectations/stylesheet.filter.css
@@ -3,8 +3,8 @@
 }
 .b {
     background-image: url("sprite.png");
-    background-position: -0px -0px;
-    background-size: 25px 25px!important;
+	background-position: -0px -0px;
+	background-size: 25px 25px!important;
 }
 .c {
     background-image: url("/a.png");

--- a/test/expectations/stylesheet.groupby.css
+++ b/test/expectations/stylesheet.groupby.css
@@ -1,15 +1,15 @@
 .a {
     background-image: url("sprite.my.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -50px;
+	background-size: 25px 75px!important;
 }
 .b {
     background-image: url("sprite.my.png");
-    background-position: -0px -25px;
-    background-size: 25px 50px!important;
+	background-position: -0px -25px;
+	background-size: 25px 75px!important;
 }
 .c {
     background-image: url("sprite.my.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -50px;
+	background-size: 25px 75px!important;
 }

--- a/test/expectations/stylesheet.retina.css
+++ b/test/expectations/stylesheet.retina.css
@@ -1,15 +1,15 @@
 @media (min-resolution: 2dppx) {
 .a {
     background-image: url("sprite.@2x.png");
-    background-position: -0px -0px;
-    background-size: 25px 50px!important;
+	background-position: -0px -0px;
+	background-size: 25px 50px!important;
     background-size: 25px 25px;
 }
 
 .b {
     background-image: url("sprite.@2x.png");
-    background-position: -0px -25px;
-    background-size: 25px 50px!important;
+	background-position: -0px -25px;
+	background-size: 25px 50px!important;
     background-size: 25px 25px;
 }
 }

--- a/test/fixtures/stylesheet.css
+++ b/test/fixtures/stylesheet.css
@@ -5,5 +5,5 @@
     background-image: url("/b.png");
 }
 .c {
-	background-image: url("/a.png");
+    background-image: url("/a.png");
 }

--- a/test/output/.gitignore
+++ b/test/output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/test.js
+++ b/test/test.js
@@ -1,489 +1,484 @@
-var fs      = require('fs'),
-    assert  = require('chai').assert,
-    File    = require('vinyl'),
-    path    = require('path'),
-    through = require('through2'),
-//    gulpif  = require("gulp-if"),
-//    rev     = require("gulp-rev"),
-    sprite  = require('./../index');
+var fs           = require('fs');
+var assert       = require('chai').assert;
+var File         = require('vinyl');
+var path         = require('path');
+var through      = require('through2');
+var sprite       = require('./../index');
+var test         = path.resolve(__dirname, '.');
+var fixtures     = path.resolve(test, 'fixtures');
+var expectations = path.resolve(test, 'expectations');
+var output       = path.resolve(test, 'output');
 
+var WRITE_EXPECTATIONS = false;
 
-function clearStr(str) {
-    return str.replace(/[\s,\r,\n,\t]/gi, "");
+function cleanCSS(str) {
+	return str.replace(/( {2,}|\t)/gi, '');
 }
 
-describe('gulp-sprite-generator', function(){
-
-    var test, fixtures, expectations;
-
-    before(function() {
-        test       = path.resolve(__dirname, '.');
-        fixtures   = path.resolve(test, 'fixtures');
-        expectations   = path.resolve(test, 'expectations');
-    });
-
-    it("should accumulate images and create common sprite from multiple stylesheets", function(done) {
-        var config, stream, errors, stylesheet, index;
-
-        index = ['A.css', 'B.css'];
-
-        stylesheet = {
-            fixtures: [path.resolve(fixtures, 'A.css'), path.resolve(fixtures, 'B.css')],
-            expectations: [path.resolve(expectations, 'A.css'), path.resolve(expectations, 'B.css')],
-        };
-
-        errors = [];
-
-        config = {
-            src:        [],
-            engine:     "auto",
-            algorithm:  "top-down",
-            padding:    0,
-            engineOpts: {},
-            exportOpts: {},
-
-            baseUrl:         fixtures,
-            spriteSheetName:  "sprite.png",
-            spriteSheetPath: null,
-            filter: [],
-            groupBy: [],
-            accumulate: true
-        };
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, config.spriteSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            var id;
-
-            id = index.indexOf(file.path);
-
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectations[id]).toString()));
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixtures[0],
-            contents: new Buffer(fs.readFileSync(stylesheet.fixtures[0]))
-        }));
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixtures[1],
-            contents: new Buffer(fs.readFileSync(stylesheet.fixtures[1]))
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should create sprite and change refs in stylesheet", function(done) {
-        var config, stream, errors, stylesheet;
-
-        stylesheet = {
-            fixture: path.resolve(fixtures, 'stylesheet.css'),
-            expectation: path.resolve(expectations, 'stylesheet.css')
-        };
-
-        errors = [];
-
-        config = {
-            src:        [],
-            engine:     "auto",
-            algorithm:  "top-down",
-            padding:    0,
-            engineOpts: {},
-            exportOpts: {},
-
-            baseUrl:         fixtures,
-            spriteSheetName:  "sprite.png",
-            styleSheetName: "stylesheet.sprite.css",
-            spriteSheetPath: null,
-            filter: [],
-            groupBy: []
-        };
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, config.spriteSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
-                assert.equal(file.path, config.styleSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixture,
-            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should create sprite for retina and change refs in stylesheet", function(done) {
-        var config, stream, errors,
-            stylesheet;
-
-        stylesheet = {
-            fixture: path.resolve(fixtures, 'stylesheet.retina.css'),
-            expectation: path.resolve(expectations, 'stylesheet.retina.css')
-        };
-
-        errors = [];
-
-        config = {
-            src:        [],
-            engine:     "auto",
-            algorithm:  "top-down",
-            padding:    0,
-            engineOpts: {},
-            exportOpts: {},
-
-            baseUrl:         fixtures,
-            spriteSheetName: "sprite.png",
-            styleSheetName:  "stylesheet.sprite.css",
-            spriteSheetPath: null,
-            filter:          [],
-            groupBy:         []
-        };
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, 'sprite.@2x.png');
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
-                assert.equal(file.path, config.styleSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixture,
-            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should create sprite using groupBy and change refs in stylesheet", function(done) {
-        var config, stream, errors,
-            stylesheet;
-
-        stylesheet = {
-            fixture: path.resolve(fixtures, 'stylesheet.css'),
-            expectation: path.resolve(expectations, 'stylesheet.groupby.css')
-        };
-
-        errors = [];
-
-        config = {
-            src:        [],
-            engine:     "auto",
-            algorithm:  "top-down",
-            padding:    0,
-            engineOpts: {},
-            exportOpts: {},
-
-            baseUrl:         fixtures,
-            spriteSheetName: "sprite.png",
-            styleSheetName:  "stylesheet.sprite.css",
-            spriteSheetPath: null,
-            filter:          [],
-            groupBy:         []
-        };
-
-        config.groupBy.push(function(image) {
-            return "my";
-        });
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, 'sprite.my.png');
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
-                assert.equal(file.path, config.styleSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixture,
-            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should create sprite using filter and change refs in stylesheet", function(done) {
-        var config, stream, errors,
-            stylesheet;
-
-        stylesheet = {
-            fixture: path.resolve(fixtures, 'stylesheet.css'),
-            expectation: path.resolve(expectations, 'stylesheet.filter.css')
-        };
-
-        errors = [];
-
-        config = {
-            src:        [],
-            engine:     "auto",
-            algorithm:  "top-down",
-            padding:    0,
-            engineOpts: {},
-            exportOpts: {},
-
-            baseUrl:         fixtures,
-            spriteSheetName: "sprite.png",
-            styleSheetName:  "stylesheet.sprite.css",
-            spriteSheetPath: null,
-            filter:          [],
-            groupBy:         []
-        };
-
-        config.filter.push(function(image) {
-            return image.url != "/a.png";
-        });
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, 'sprite.png');
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
-                assert.equal(file.path, config.styleSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixture,
-            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should create sprite reading meta in doc block and change refs in stylesheet", function(done) {
-        var config, stream, errors,
-            meta;
-
-        errors = [];
-
-        config = {
-            baseUrl:         fixtures,
-            spriteSheetName: "sprite.png",
-            filter:          []
-        };
-
-        meta = {
-            sprite: {
-                some: true,
-                prop: 1,
-                yes: "no"
-            }
-        };
-
-        config.filter.push(function(image) {
-            try {
-                assert.deepEqual(image.meta, meta.sprite);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream = sprite(config);
-
-        stream.write(new File({
-            base:     test,
-            path:     path.resolve(fixtures, 'stylesheetdddd.css'),
-            contents: new Buffer('.a { background-image: url("sprite.retina-2x.png"); /* @meta ' + JSON.stringify(meta) + ' */ }')
-        }));
-
-        stream.on('finish', function() {
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
-    it("Should pipe properly", function(done) {
-        var config, stream, errors, stylesheet,
-            piped;
-
-        piped = {
-            img: 0,
-            css: 0,
-            main: 0
-        };
-
-        stylesheet = {
-            fixture: path.resolve(fixtures, 'stylesheet.css'),
-            expectation: path.resolve(expectations, 'stylesheet.css')
-        };
-
-        errors = [];
-
-        config = {
-            baseUrl:         fixtures,
-            spriteSheetName:  "sprite.png",
-            styleSheetName: "stylesheet.sprite.css",
-            spriteSheetPath: null,
-            filter: [],
-            groupBy: []
-        };
-
-        stream = sprite(config);
-
-        stream.img.on('data', function (file) {
-            try {
-                assert.equal(file.path, config.spriteSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.css.on('data', function (file) {
-            try {
-                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
-                assert.equal(file.path, config.styleSheetName);
-            } catch (err) {
-                errors.push(err);
-            }
-        });
-
-        stream.write(new File({
-            base:     test,
-            path:     stylesheet.fixture,
-            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-        }));
-
-
-        stream.pipe(through.obj(function(file, enc, done) {
-            piped.main++;
-            try {
-                assert.instanceOf(file, File, "Piped in a main stream obj is not a File");
-            } catch (err) {
-                errors.push(err);
-            }
-        }));
-
-        stream.css.pipe(through.obj(function(file, enc, done) {
-            piped.css++;
-            try {
-                assert.instanceOf(file, File, "Piped in a css stream obj is not a File");
-            } catch (err) {
-                errors.push(err);
-            }
-        }));
-
-        stream.img.pipe(through.obj(function(file, enc, done) {
-            piped.img++;
-            try {
-                assert.instanceOf(file, File, "Piped in a img stream obj is not a File");
-            } catch (err) {
-                errors.push(err);
-            }
-        }));
-
-//        stream.img
-//            .pipe(rev())
-//            .pipe(through.obj(function(file, enc, done) {
-//                console.log('revision', file.path);
-//                this.push(file);
-//                done();
-//            }))
-//            .pipe(rev.manifest())
-//            .pipe(through.obj(function(file, enc, done) {
-//                console.log('manifest', file);
-//                this.push(file);
-//                done();
-//            }));
-
-        stream.on('finish', function() {
-            try {
-                assert.equal(1, piped.img,  "No piped data in img stream");
-                assert.equal(1, piped.css,  "No piped data in css stream");
-                assert.equal(1, piped.main, "No piped data in main stream");
-            } catch (err) {
-                errors.push(err);
-            }
-
-            done(errors[0]);
-        });
-
-        stream.end();
-    });
-
+function assertCSS(a, expectedFile) {
+	if (WRITE_EXPECTATIONS) fs.writeFileSync(expectedFile, a, 'utf8');
+	var b = fs.readFileSync(expectedFile, 'utf8');
+	assert.deepEqual(cleanCSS(a), cleanCSS(b));
+}
+
+var visualSpriteID = 0;
+function saveSpriteForVisualInspection(file) {
+	var outputFile = output + '/sprite' + (++visualSpriteID) + '.png';
+	fs.writeFileSync(outputFile, file.contents);
+}
+
+describe('gulp-sprite-generator', function() {
+
+	it('should accumulate images and create common sprite from multiple stylesheets', function(done) {
+		var config, stream, errors, stylesheet, index;
+
+		index = ['A.css', 'B.css'];
+
+		stylesheet = {
+			fixtures: [path.resolve(fixtures, 'A.css'), path.resolve(fixtures, 'B.css')],
+			expectations: [path.resolve(expectations, 'A.css'), path.resolve(expectations, 'B.css')],
+		};
+
+		errors = [];
+
+		config = {
+			src: [],
+			engine: null,
+			algorithm: 'top-down',
+			padding: 0,
+			engineOpts: {},
+			exportOpts: {},
+
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: [],
+			accumulate: true
+		};
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, config.spriteSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			var id;
+
+			id = index.indexOf(file.path);
+
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectations[id]);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixtures[0],
+			contents: new Buffer(fs.readFileSync(stylesheet.fixtures[0]))
+		}));
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixtures[1],
+			contents: new Buffer(fs.readFileSync(stylesheet.fixtures[1]))
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should create sprite and change refs in stylesheet', function(done) {
+		var config, stream, errors, stylesheet;
+
+		stylesheet = {
+			fixture: path.resolve(fixtures, 'stylesheet.css'),
+			expectation: path.resolve(expectations, 'stylesheet.css')
+		};
+
+		errors = [];
+
+		config = {
+			src: [],
+			engine:	 null,
+			algorithm:	'top-down',
+			padding:	0,
+			engineOpts: {},
+			exportOpts: {},
+
+			baseUrl: fixtures,
+			spriteSheetName:	'sprite.png',
+			styleSheetName: 'stylesheet.sprite.css',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: []
+		};
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, config.spriteSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectation);
+				assert.equal(file.path, config.styleSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixture,
+			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should create sprite for retina and change refs in stylesheet', function(done) {
+		var config, stream, errors, stylesheet;
+
+		stylesheet = {
+			fixture: path.resolve(fixtures, 'stylesheet.retina.css'),
+			expectation: path.resolve(expectations, 'stylesheet.retina.css')
+		};
+
+		errors = [];
+		config = {
+			src: [],
+			engine: null,
+			algorithm: 'top-down',
+			padding: 0,
+			engineOpts: {},
+			exportOpts: {},
+
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			styleSheetName:	'stylesheet.sprite.css',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: []
+		};
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, 'sprite.@2x.png');
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectation);
+				assert.equal(file.path, config.styleSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixture,
+			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should create sprite using groupBy and change refs in stylesheet', function(done) {
+		var config, stream, errors, stylesheet;
+
+		stylesheet = {
+			fixture: path.resolve(fixtures, 'stylesheet.css'),
+			expectation: path.resolve(expectations, 'stylesheet.groupby.css')
+		};
+
+		errors = [];
+
+		config = {
+			src: [],
+			engine: null,
+			algorithm: 'top-down',
+			padding: 0,
+			engineOpts: {},
+			exportOpts: {},
+
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			styleSheetName:	'stylesheet.sprite.css',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: []
+		};
+
+		config.groupBy.push(function(image) {
+			return 'my';
+		});
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, 'sprite.my.png');
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectation);
+				assert.equal(file.path, config.styleSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixture,
+			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should create sprite using filter and change refs in stylesheet', function(done) {
+		var config, stream, errors, stylesheet;
+
+		stylesheet = {
+			fixture: path.resolve(fixtures, 'stylesheet.css'),
+			expectation: path.resolve(expectations, 'stylesheet.filter.css')
+		};
+
+		errors = [];
+
+		config = {
+			src: [],
+			engine: null,
+			algorithm: 'top-down',
+			padding:	0,
+			engineOpts: {},
+			exportOpts: {},
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			styleSheetName:	'stylesheet.sprite.css',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: []
+		};
+
+		config.filter.push(function(image) {
+			return image.url != '/a.png';
+		});
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, 'sprite.png');
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectation);
+				assert.equal(file.path, config.styleSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixture,
+			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should create sprite reading meta in doc block and change refs in stylesheet', function(done) {
+		var config, stream, errors, meta;
+
+		errors = [];
+
+		config = {
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			filter: []
+		};
+
+		meta = {
+			sprite: {
+				some: true,
+				prop: 1,
+				yes: 'no'
+			}
+		};
+
+		config.filter.push(function(image) {
+			try {
+				assert.deepEqual(image.meta, meta.sprite);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream = sprite(config);
+
+		stream.write(new File({
+			base: test,
+			path: path.resolve(fixtures, 'stylesheetdddd.css'),
+			contents: new Buffer('.a { background-image: url("sprite.retina-2x.png"); /* @meta ' + JSON.stringify(meta) + ' */ }')
+		}));
+
+		stream.on('finish', function() {
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
+
+	it('Should pipe properly', function(done) {
+		var config, stream, errors, stylesheet, piped;
+
+		piped = {
+			img: 0,
+			css: 0,
+			main: 0
+		};
+
+		stylesheet = {
+			fixture: path.resolve(fixtures, 'stylesheet.css'),
+			expectation: path.resolve(expectations, 'stylesheet.css')
+		};
+
+		errors = [];
+
+		config = {
+			baseUrl: fixtures,
+			spriteSheetName: 'sprite.png',
+			styleSheetName: 'stylesheet.sprite.css',
+			spriteSheetPath: null,
+			filter: [],
+			groupBy: []
+		};
+
+		stream = sprite(config);
+
+		stream.img.on('data', function (file) {
+			try {
+				saveSpriteForVisualInspection(file);
+				assert.equal(file.path, config.spriteSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.css.on('data', function (file) {
+			try {
+				assertCSS(file.contents.toString(), stylesheet.expectation);
+				assert.equal(file.path, config.styleSheetName);
+			} catch (err) {
+				errors.push(err);
+			}
+		});
+
+		stream.write(new File({
+			base: test,
+			path: stylesheet.fixture,
+			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+		}));
+
+
+		stream.pipe(through.obj(function(file, enc, done) {
+			piped.main++;
+			try {
+				assert.instanceOf(file, File, 'Piped in a main stream obj is not a File');
+			} catch (err) {
+				errors.push(err);
+			}
+		}));
+
+		stream.css.pipe(through.obj(function(file, enc, done) {
+			piped.css++;
+			try {
+				assert.instanceOf(file, File, 'Piped in a css stream obj is not a File');
+			} catch (err) {
+				errors.push(err);
+			}
+		}));
+
+		stream.img.pipe(through.obj(function(file, enc, done) {
+			piped.img++;
+			try {
+				assert.instanceOf(file, File, 'Piped in a img stream obj is not a File');
+			} catch (err) {
+				errors.push(err);
+			}
+		}));
+
+		stream.on('error', function(e) {
+			console.error('Encountered stream error:');
+			console.error(e.stack);
+			errors.push(err);
+		});
+		stream.on('finish', function() {
+			try {
+				assert.equal(1, piped.img, 'No piped data in img stream');
+				assert.equal(1, piped.css, 'No piped data in css stream');
+				assert.equal(1, piped.main, 'No piped data in main stream');
+			} catch (err) {
+				errors.push(err);
+			}
+
+			done(errors[0]);
+		});
+
+		stream.end();
+	});
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -12,473 +12,473 @@ var output       = path.resolve(test, 'output');
 var WRITE_EXPECTATIONS = false;
 
 function cleanCSS(str) {
-	return str.replace(/( {2,}|\t)/gi, '');
+    return str.replace(/( {2,}|\t)/gi, '');
 }
 
 function assertCSS(a, expectedFile) {
-	if (WRITE_EXPECTATIONS) fs.writeFileSync(expectedFile, a, 'utf8');
-	var b = fs.readFileSync(expectedFile, 'utf8');
-	assert.deepEqual(cleanCSS(a), cleanCSS(b));
+    if (WRITE_EXPECTATIONS) fs.writeFileSync(expectedFile, a, 'utf8');
+    var b = fs.readFileSync(expectedFile, 'utf8');
+    assert.deepEqual(cleanCSS(a), cleanCSS(b));
 }
 
 var visualSpriteID = 0;
 function saveSpriteForVisualInspection(file) {
-	var outputFile = output + '/sprite' + (++visualSpriteID) + '.png';
-	fs.writeFileSync(outputFile, file.contents);
+    var outputFile = output + '/sprite' + (++visualSpriteID) + '.png';
+    fs.writeFileSync(outputFile, file.contents);
 }
 
 describe('gulp-sprite-generator', function() {
 
-	it('should accumulate images and create common sprite from multiple stylesheets', function(done) {
-		var config, stream, errors, stylesheet, index;
-
-		index = ['A.css', 'B.css'];
-
-		stylesheet = {
-			fixtures: [path.resolve(fixtures, 'A.css'), path.resolve(fixtures, 'B.css')],
-			expectations: [path.resolve(expectations, 'A.css'), path.resolve(expectations, 'B.css')],
-		};
-
-		errors = [];
-
-		config = {
-			src: [],
-			engine: null,
-			algorithm: 'top-down',
-			padding: 0,
-			engineOpts: {},
-			exportOpts: {},
-
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: [],
-			accumulate: true
-		};
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, config.spriteSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			var id;
-
-			id = index.indexOf(file.path);
-
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectations[id]);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixtures[0],
-			contents: new Buffer(fs.readFileSync(stylesheet.fixtures[0]))
-		}));
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixtures[1],
-			contents: new Buffer(fs.readFileSync(stylesheet.fixtures[1]))
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should create sprite and change refs in stylesheet', function(done) {
-		var config, stream, errors, stylesheet;
-
-		stylesheet = {
-			fixture: path.resolve(fixtures, 'stylesheet.css'),
-			expectation: path.resolve(expectations, 'stylesheet.css')
-		};
-
-		errors = [];
-
-		config = {
-			src: [],
-			engine:	 null,
-			algorithm:	'top-down',
-			padding:	0,
-			engineOpts: {},
-			exportOpts: {},
-
-			baseUrl: fixtures,
-			spriteSheetName:	'sprite.png',
-			styleSheetName: 'stylesheet.sprite.css',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: []
-		};
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, config.spriteSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectation);
-				assert.equal(file.path, config.styleSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixture,
-			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should create sprite for retina and change refs in stylesheet', function(done) {
-		var config, stream, errors, stylesheet;
-
-		stylesheet = {
-			fixture: path.resolve(fixtures, 'stylesheet.retina.css'),
-			expectation: path.resolve(expectations, 'stylesheet.retina.css')
-		};
-
-		errors = [];
-		config = {
-			src: [],
-			engine: null,
-			algorithm: 'top-down',
-			padding: 0,
-			engineOpts: {},
-			exportOpts: {},
-
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			styleSheetName:	'stylesheet.sprite.css',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: []
-		};
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, 'sprite.@2x.png');
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectation);
-				assert.equal(file.path, config.styleSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixture,
-			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should create sprite using groupBy and change refs in stylesheet', function(done) {
-		var config, stream, errors, stylesheet;
-
-		stylesheet = {
-			fixture: path.resolve(fixtures, 'stylesheet.css'),
-			expectation: path.resolve(expectations, 'stylesheet.groupby.css')
-		};
-
-		errors = [];
-
-		config = {
-			src: [],
-			engine: null,
-			algorithm: 'top-down',
-			padding: 0,
-			engineOpts: {},
-			exportOpts: {},
-
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			styleSheetName:	'stylesheet.sprite.css',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: []
-		};
-
-		config.groupBy.push(function(image) {
-			return 'my';
-		});
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, 'sprite.my.png');
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectation);
-				assert.equal(file.path, config.styleSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixture,
-			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should create sprite using filter and change refs in stylesheet', function(done) {
-		var config, stream, errors, stylesheet;
-
-		stylesheet = {
-			fixture: path.resolve(fixtures, 'stylesheet.css'),
-			expectation: path.resolve(expectations, 'stylesheet.filter.css')
-		};
-
-		errors = [];
-
-		config = {
-			src: [],
-			engine: null,
-			algorithm: 'top-down',
-			padding:	0,
-			engineOpts: {},
-			exportOpts: {},
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			styleSheetName:	'stylesheet.sprite.css',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: []
-		};
-
-		config.filter.push(function(image) {
-			return image.url != '/a.png';
-		});
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, 'sprite.png');
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectation);
-				assert.equal(file.path, config.styleSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixture,
-			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should create sprite reading meta in doc block and change refs in stylesheet', function(done) {
-		var config, stream, errors, meta;
-
-		errors = [];
-
-		config = {
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			filter: []
-		};
-
-		meta = {
-			sprite: {
-				some: true,
-				prop: 1,
-				yes: 'no'
-			}
-		};
-
-		config.filter.push(function(image) {
-			try {
-				assert.deepEqual(image.meta, meta.sprite);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream = sprite(config);
-
-		stream.write(new File({
-			base: test,
-			path: path.resolve(fixtures, 'stylesheetdddd.css'),
-			contents: new Buffer('.a { background-image: url("sprite.retina-2x.png"); /* @meta ' + JSON.stringify(meta) + ' */ }')
-		}));
-
-		stream.on('finish', function() {
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
-
-	it('Should pipe properly', function(done) {
-		var config, stream, errors, stylesheet, piped;
-
-		piped = {
-			img: 0,
-			css: 0,
-			main: 0
-		};
-
-		stylesheet = {
-			fixture: path.resolve(fixtures, 'stylesheet.css'),
-			expectation: path.resolve(expectations, 'stylesheet.css')
-		};
-
-		errors = [];
-
-		config = {
-			baseUrl: fixtures,
-			spriteSheetName: 'sprite.png',
-			styleSheetName: 'stylesheet.sprite.css',
-			spriteSheetPath: null,
-			filter: [],
-			groupBy: []
-		};
-
-		stream = sprite(config);
-
-		stream.img.on('data', function (file) {
-			try {
-				saveSpriteForVisualInspection(file);
-				assert.equal(file.path, config.spriteSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.css.on('data', function (file) {
-			try {
-				assertCSS(file.contents.toString(), stylesheet.expectation);
-				assert.equal(file.path, config.styleSheetName);
-			} catch (err) {
-				errors.push(err);
-			}
-		});
-
-		stream.write(new File({
-			base: test,
-			path: stylesheet.fixture,
-			contents: new Buffer(fs.readFileSync(stylesheet.fixture))
-		}));
-
-
-		stream.pipe(through.obj(function(file, enc, done) {
-			piped.main++;
-			try {
-				assert.instanceOf(file, File, 'Piped in a main stream obj is not a File');
-			} catch (err) {
-				errors.push(err);
-			}
-		}));
-
-		stream.css.pipe(through.obj(function(file, enc, done) {
-			piped.css++;
-			try {
-				assert.instanceOf(file, File, 'Piped in a css stream obj is not a File');
-			} catch (err) {
-				errors.push(err);
-			}
-		}));
-
-		stream.img.pipe(through.obj(function(file, enc, done) {
-			piped.img++;
-			try {
-				assert.instanceOf(file, File, 'Piped in a img stream obj is not a File');
-			} catch (err) {
-				errors.push(err);
-			}
-		}));
-
-		stream.on('error', function(e) {
-			console.error('Encountered stream error:');
-			console.error(e.stack);
-			errors.push(err);
-		});
-		stream.on('finish', function() {
-			try {
-				assert.equal(1, piped.img, 'No piped data in img stream');
-				assert.equal(1, piped.css, 'No piped data in css stream');
-				assert.equal(1, piped.main, 'No piped data in main stream');
-			} catch (err) {
-				errors.push(err);
-			}
-
-			done(errors[0]);
-		});
-
-		stream.end();
-	});
+    it('should accumulate images and create common sprite from multiple stylesheets', function(done) {
+        var config, stream, errors, stylesheet, index;
+
+        index = ['A.css', 'B.css'];
+
+        stylesheet = {
+            fixtures: [path.resolve(fixtures, 'A.css'), path.resolve(fixtures, 'B.css')],
+            expectations: [path.resolve(expectations, 'A.css'), path.resolve(expectations, 'B.css')],
+        };
+
+        errors = [];
+
+        config = {
+            src: [],
+            engine: null,
+            algorithm: 'top-down',
+            padding: 0,
+            engineOpts: {},
+            exportOpts: {},
+
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: [],
+            accumulate: true
+        };
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, config.spriteSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            var id;
+
+            id = index.indexOf(file.path);
+
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectations[id]);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixtures[0],
+            contents: new Buffer(fs.readFileSync(stylesheet.fixtures[0]))
+        }));
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixtures[1],
+            contents: new Buffer(fs.readFileSync(stylesheet.fixtures[1]))
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should create sprite and change refs in stylesheet', function(done) {
+        var config, stream, errors, stylesheet;
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.css'),
+            expectation: path.resolve(expectations, 'stylesheet.css')
+        };
+
+        errors = [];
+
+        config = {
+            src: [],
+            engine:     null,
+            algorithm:    'top-down',
+            padding:    0,
+            engineOpts: {},
+            exportOpts: {},
+
+            baseUrl: fixtures,
+            spriteSheetName:    'sprite.png',
+            styleSheetName: 'stylesheet.sprite.css',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: []
+        };
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, config.spriteSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectation);
+                assert.equal(file.path, config.styleSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixture,
+            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should create sprite for retina and change refs in stylesheet', function(done) {
+        var config, stream, errors, stylesheet;
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.retina.css'),
+            expectation: path.resolve(expectations, 'stylesheet.retina.css')
+        };
+
+        errors = [];
+        config = {
+            src: [],
+            engine: null,
+            algorithm: 'top-down',
+            padding: 0,
+            engineOpts: {},
+            exportOpts: {},
+
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            styleSheetName:    'stylesheet.sprite.css',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: []
+        };
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, 'sprite.@2x.png');
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectation);
+                assert.equal(file.path, config.styleSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixture,
+            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should create sprite using groupBy and change refs in stylesheet', function(done) {
+        var config, stream, errors, stylesheet;
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.css'),
+            expectation: path.resolve(expectations, 'stylesheet.groupby.css')
+        };
+
+        errors = [];
+
+        config = {
+            src: [],
+            engine: null,
+            algorithm: 'top-down',
+            padding: 0,
+            engineOpts: {},
+            exportOpts: {},
+
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            styleSheetName:    'stylesheet.sprite.css',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: []
+        };
+
+        config.groupBy.push(function(image) {
+            return 'my';
+        });
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, 'sprite.my.png');
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectation);
+                assert.equal(file.path, config.styleSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixture,
+            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should create sprite using filter and change refs in stylesheet', function(done) {
+        var config, stream, errors, stylesheet;
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.css'),
+            expectation: path.resolve(expectations, 'stylesheet.filter.css')
+        };
+
+        errors = [];
+
+        config = {
+            src: [],
+            engine: null,
+            algorithm: 'top-down',
+            padding:    0,
+            engineOpts: {},
+            exportOpts: {},
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            styleSheetName:    'stylesheet.sprite.css',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: []
+        };
+
+        config.filter.push(function(image) {
+            return image.url != '/a.png';
+        });
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, 'sprite.png');
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectation);
+                assert.equal(file.path, config.styleSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixture,
+            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should create sprite reading meta in doc block and change refs in stylesheet', function(done) {
+        var config, stream, errors, meta;
+
+        errors = [];
+
+        config = {
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            filter: []
+        };
+
+        meta = {
+            sprite: {
+                some: true,
+                prop: 1,
+                yes: 'no'
+            }
+        };
+
+        config.filter.push(function(image) {
+            try {
+                assert.deepEqual(image.meta, meta.sprite);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream = sprite(config);
+
+        stream.write(new File({
+            base: test,
+            path: path.resolve(fixtures, 'stylesheetdddd.css'),
+            contents: new Buffer('.a { background-image: url("sprite.retina-2x.png"); /* @meta ' + JSON.stringify(meta) + ' */ }')
+        }));
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
+    it('Should pipe properly', function(done) {
+        var config, stream, errors, stylesheet, piped;
+
+        piped = {
+            img: 0,
+            css: 0,
+            main: 0
+        };
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.css'),
+            expectation: path.resolve(expectations, 'stylesheet.css')
+        };
+
+        errors = [];
+
+        config = {
+            baseUrl: fixtures,
+            spriteSheetName: 'sprite.png',
+            styleSheetName: 'stylesheet.sprite.css',
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: []
+        };
+
+        stream = sprite(config);
+
+        stream.img.on('data', function (file) {
+            try {
+                saveSpriteForVisualInspection(file);
+                assert.equal(file.path, config.spriteSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.css.on('data', function (file) {
+            try {
+                assertCSS(file.contents.toString(), stylesheet.expectation);
+                assert.equal(file.path, config.styleSheetName);
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.write(new File({
+            base: test,
+            path: stylesheet.fixture,
+            contents: new Buffer(fs.readFileSync(stylesheet.fixture))
+        }));
+
+
+        stream.pipe(through.obj(function(file, enc, done) {
+            piped.main++;
+            try {
+                assert.instanceOf(file, File, 'Piped in a main stream obj is not a File');
+            } catch (err) {
+                errors.push(err);
+            }
+        }));
+
+        stream.css.pipe(through.obj(function(file, enc, done) {
+            piped.css++;
+            try {
+                assert.instanceOf(file, File, 'Piped in a css stream obj is not a File');
+            } catch (err) {
+                errors.push(err);
+            }
+        }));
+
+        stream.img.pipe(through.obj(function(file, enc, done) {
+            piped.img++;
+            try {
+                assert.instanceOf(file, File, 'Piped in a img stream obj is not a File');
+            } catch (err) {
+                errors.push(err);
+            }
+        }));
+
+        stream.on('error', function(e) {
+            console.error('Encountered stream error:');
+            console.error(e.stack);
+            errors.push(err);
+        });
+        stream.on('finish', function() {
+            try {
+                assert.equal(1, piped.img, 'No piped data in img stream');
+                assert.equal(1, piped.css, 'No piped data in css stream');
+                assert.equal(1, piped.main, 'No piped data in main stream');
+            } catch (err) {
+                errors.push(err);
+            }
+
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
 });


### PR DESCRIPTION
- Official support for Node 4/5
- Better error handling (there were a few places where errors weren't being handled, which caused gulp to silently stop without any info)
- Updated [spritesmith](https://github.com/Ensighten/spritesmith) `0.18.0` -> `3.1.0`
- Updated [lodash](https://www.npmjs.com/package/lodash) `2.4.1` -> `4.1.1`
- Updated [through2](https://www.npmjs.com/package/through2) `0.4.1` -> `2.0.1`
- Updated [async](https://www.npmjs.com/package/async) `0.2.10` -> `2.0.0-rc.3`
- Updated [vinyl](https://github.com/gulpjs/vinyl) `0.2.3` -> `1.1.1`
- Dropped [Q](https://github.com/kriskowal/q) in favor of [es6-promise](https://www.npmjs.com/package/es6-promise) (easier to drop later when promises are mainstream)

p.s. sorry in advance for style changes
