### PR TITLE
Implement a way to set CSS width and height

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Tells sprite-generator to accumulate images from multiple stylesheets. This mean
 Type: `Boolean`
 Default value: `false`
 
-#### options.verbose
+#### options.setWidthAndHeight
 Type: `Boolean`
 Default value: `false`
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,18 @@ More detailed explanation you can find on the [official page of spritesmith](htt
 
 **Plugin options** are:
 
-Property          | Necessary | Type         | Plugin default value
-------------------|-----------|--------------|-----------
-spriteSheetName   | **yes**   | `String`     | `null`
-[spriteSheetPath] | no        | `String`     | `null`
-[styleSheetName]  | np        | `String`     | `null`
-[baseUrl]         | no        | `String`     | `"./"`
-[retina]          | no        | `Boolean`    | `true`
-[filter]          | no        | `Function[]` | `[]`
-[groupBy]         | no        | `Function[]` | `[]`
-[accumulate]      | no        | `Boolean`    | `false`
-[verbose]         | no        | `Boolean`    | `false`
+Property           | Necessary | Type         | Plugin default value
+-------------------|-----------|--------------|-----------
+spriteSheetName    | **yes**   | `String`     | `null`
+[spriteSheetPath]  | no        | `String`     | `null`
+[styleSheetName]   | np        | `String`     | `null`
+[baseUrl]          | no        | `String`     | `"./"`
+[retina]           | no        | `Boolean`    | `true`
+[filter]           | no        | `Function[]` | `[]`
+[groupBy]          | no        | `Function[]` | `[]`
+[accumulate]       | no        | `Boolean`    | `false`
+[verbose]          | no        | `Boolean`    | `false`
+[setWidthAndHeight]| no        | `Boolean`    | `false`
 
 More detailed explanation is below.
 
@@ -135,6 +136,13 @@ Tells sprite-generator to accumulate images from multiple stylesheets. This mean
 #### options.verbose
 Type: `Boolean`
 Default value: `false`
+
+#### options.verbose
+Type: `Boolean`
+Default value: `false`
+
+If `true`, CSS `width` and `height` rules matching the image dimensions will be created
+in addition to the `background-size` rule.
 
 ### Filtering and grouping
 
@@ -234,4 +242,3 @@ gulp.task('sprites', function() {
 ## License
 
 MIT © [Sergey Kamardin](http://github.com/gobwas)
-

--- a/test/expectations/stylesheet.wh.css
+++ b/test/expectations/stylesheet.wh.css
@@ -1,0 +1,21 @@
+.a {
+    background-image: url("sprite.png");
+    background-position: -0px -0px;
+    background-size: 25px 50px!important;
+    width: 25px;
+    height: 50px;
+}
+.b {
+    background-image: url("sprite.png");
+    background-position: -0px -25px;
+    background-size: 25px 50px!important;
+    width: 25px;
+    height: 50px;
+}
+.c {
+    background-image: url("sprite.png");
+    background-position: -0px -0px;
+    background-size: 25px 50px!important;
+    width: 25px;
+    height: 50px;    
+}

--- a/test/test.js
+++ b/test/test.js
@@ -377,6 +377,50 @@ describe('gulp-sprite-generator', function(){
         stream.end();
     });
 
+    it("should set width and height correctly", function(done) {
+        var config, stream, errors, stylesheet;
+
+        stylesheet = {
+            fixture: path.resolve(fixtures, 'stylesheet.css'),
+            expectation: path.resolve(expectations, 'stylesheet.wh.css')
+        };
+
+        errors = [];
+
+        config = {
+            src:        [],
+            engine:     "auto",
+            algorithm:  "top-down",
+            padding:    0,
+            engineOpts: {},
+            exportOpts: {},
+
+            baseUrl:         fixtures,
+            spriteSheetName:  "sprite.png",
+            styleSheetName: "stylesheet.wh.css",
+            spriteSheetPath: null,
+            filter: [],
+            groupBy: [],
+            setWidthAndHeight: true
+        };
+
+        stream = sprite(config);
+
+        stream.css.on('data', function (file) {
+            try {
+                assert.equal(clearStr(file.contents.toString()), clearStr(fs.readFileSync(stylesheet.expectation).toString()));
+            } catch (err) {
+                errors.push(err);
+            }
+        });
+
+        stream.on('finish', function() {
+            done(errors[0]);
+        });
+
+        stream.end();
+    });
+
     it("Should pipe properly", function(done) {
         var config, stream, errors, stylesheet,
             piped;
@@ -486,4 +530,3 @@ describe('gulp-sprite-generator', function(){
     });
 
 });
-


### PR DESCRIPTION
I implemented an option (`setWidthAndHeight`) to add CSS `width` and `height` rules in the output in addition to the already generated `background-size` rule (and added a test and documentation for it). This makes it possible to use the plugin to generate classes for standalone icons/images like this:

```
<div class="some-logo"></div>
```

With CSS:

```
some-logo {
    background-image: url(/some/image.png);
}
```

While pulling compass (which did spritesheet generation and enabled this kind of icons) out of our project, I found your plugin and really liked how it worked, the only thing missing to completely replace our compass use was a way to set `width` and `height` to the same values as `background-size`, so I added that.

Maybe it will help other people too :-)
